### PR TITLE
fix: round the value before entering in comparing mode to avoid round…

### DIFF
--- a/website_sale_product_pricelist_alternative/models/product_template.py
+++ b/website_sale_product_pricelist_alternative/models/product_template.py
@@ -15,8 +15,11 @@ class ProductTemplate(models.Model):
         ):
             pricelist = pricelist.with_context(skip_alternative_pricelist=True)
             res = super()._get_sales_prices(pricelist)
+            precision = self.sudo().env["decimal.precision"].precision_get("Discount")
             for product_id in res:
-                res[product_id]["base_price"] = res[product_id]["price_reduce"]
+                res[product_id]["base_price"] = round(
+                    res[product_id]["price_reduce"], precision
+                )
                 pricelist = pricelist.with_context(skip_alternative_pricelist=False)
                 product = self.env["product.template"].browse(product_id)
                 res[product_id]["price_reduce"] = pricelist._get_product_price(


### PR DESCRIPTION
When we assigned the price, we need to round it to avoid, comparaison failed for strike price

I can't call the round on the pricelist, it will go on recursive function.

So I get the precision on the discount configuration